### PR TITLE
Update SentenceClassifier.lua

### DIFF
--- a/src/eval/SentenceClassifier.lua
+++ b/src/eval/SentenceClassifier.lua
@@ -35,7 +35,8 @@ function SentenceClassifier:__init(params)
 
     -- load model
     local model = torch.load(self.params.model)
-    self.kb_encoder = self:to_cuda(model.kb_col_table and model.kb_col_table or (model.row_encoder and model.row_encoder or (model.col_encoder and model.col_encoder or model.encoder)))
+    -- self.kb_encoder = self:to_cuda(model.kb_col_table and model.kb_col_table or (model.row_encoder and model.row_encoder or (model.col_encoder and model.col_encoder or model.encoder)))
+    self.kb_encoder = self:to_cuda(model.kb_col_table and model.kb_col_table or (model.col_encoder and model.col_encoder or (model.row_encoder and model.row_encoder or model.encoder)))
     self.text_encoder = self:to_cuda(model.text_encoder and model.text_encoder or (model.col_encoder and model.col_encoder or model.encoder))
     self.net = self:to_cuda(model.net)
     self.net:evaluate(); self.kb_encoder:evaluate(); self.text_encoder:evaluate()


### PR DESCRIPTION
The existing version causes the entity pair encoders to be load into `self.kb_encoder`. Only col_encoder shall be read at test time.
